### PR TITLE
Return appropriate HTTP status codes on error

### DIFF
--- a/application.py
+++ b/application.py
@@ -53,7 +53,7 @@ def version():
 
 @app.errorhandler(429)
 def limit_rate(e):
-    return jsonify(Error.RATE_TOOFAST)
+    return Error.RATE_TOOFAST
 
 
 app.register_blueprint(subscription)

--- a/controllers/gcm.py
+++ b/controllers/gcm.py
@@ -20,7 +20,7 @@ def gcm_register(client):
     reg = Gcm(client, registration)
     db.session.add(reg)
     db.session.commit()
-    return jsonify(Error.NONE)
+    return Error.NONE
 
 
 @gcm.route("/gcm", methods=["DELETE"])
@@ -30,7 +30,7 @@ def gcm_unregister(client):
     for u in regs:
         db.session.delete(u)
     db.session.commit()
-    return jsonify(Error.NONE)
+    return Error.NONE
 
 
 @gcm.route("/gcm", methods=["GET"])

--- a/controllers/message.py
+++ b/controllers/message.py
@@ -16,13 +16,13 @@ message = Blueprint('message', __name__)
 def message_send(service):
     text = request.form.get('message')
     if not text:
-        return jsonify(Error.ARGUMENT_MISSING('message'))
+        return Error.ARGUMENT_MISSING('message')
 
     subscribers = Subscription.query.filter_by(service=service).count()
     if subscribers == 0:
         # Pretend we did something even though we didn't
         # Nobody is listening so it doesn't really matter
-        return jsonify(Error.NONE)
+        return Error.NONE
 
     level = (request.form.get('level') or '3')[0]
     level = int(level) if level in "12345" else 3
@@ -40,7 +40,7 @@ def message_send(service):
 
     service.cleanup()
     db.session.commit()
-    return jsonify(Error.NONE)
+    return Error.NONE
 
 
 @message.route('/message', methods=['GET'])
@@ -79,4 +79,4 @@ def message_read(client):
             l.service.cleanup()
         db.session.commit()
 
-    return jsonify(Error.NONE)
+    return Error.NONE

--- a/controllers/service.py
+++ b/controllers/service.py
@@ -13,7 +13,7 @@ def service_create():
     name = request.form.get('name', '').strip()
     icon = request.form.get('icon', '').strip()
     if not name:
-        return jsonify(Error.ARGUMENT_MISSING('name'))
+        return Error.ARGUMENT_MISSING('name')
     srv = Service(name, icon)
     db.session.add(srv)
     db.session.commit()
@@ -27,23 +27,23 @@ def service_info():
 
     if service_:
         if not is_service(service_):
-            return jsonify(Error.INVALID_SERVICE)
+            return Error.INVALID_SERVICE
 
         srv = Service.query.filter_by(public=service_).first()
         if not srv:
-            return jsonify(Error.SERVICE_NOTFOUND)
+            return Error.SERVICE_NOTFOUND
         return jsonify({"service": srv.as_dict()})
 
     if secret:
         if not is_secret(secret):
-            return jsonify(Error.INVALID_SECRET)
+            return Error.INVALID_SECRET
 
         srv = Service.query.filter_by(secret=secret).first()
         if not srv:
-            return jsonify(Error.SERVICE_NOTFOUND)
+            return Error.SERVICE_NOTFOUND
         return jsonify({"service": srv.as_dict()})
 
-    return jsonify(Error.ARGUMENT_MISSING('service'))
+    return Error.ARGUMENT_MISSING('service')
 
 
 @service.route('/service', methods=['DELETE'])
@@ -69,7 +69,7 @@ def service_delete(service):
     if zeromq_relay_uri:
         map(queue_zmq_message, send_later)
 
-    return jsonify(Error.NONE)
+    return Error.NONE
 
 
 @service.route('/service', methods=['PATCH'])
@@ -86,6 +86,6 @@ def service_patch(service):
 
     if updated:
         db.session.commit()
-        return jsonify(Error.NONE)
+        return Error.NONE
     else:
-        return jsonify(Error.NO_CHANGES)
+        return Error.NO_CHANGES

--- a/controllers/subscription.py
+++ b/controllers/subscription.py
@@ -14,7 +14,7 @@ subscription = Blueprint('subscription', __name__)
 def subscription_post(client, service):
     exists = Subscription.query.filter_by(device=client).filter_by(service=service).first() is not None
     if exists:
-        return jsonify(Error.DUPLICATE_LISTEN)
+        return Error.DUPLICATE_LISTEN
 
     subscription_new = Subscription(client, service)
     db.session.add(subscription_new)
@@ -41,4 +41,4 @@ def subscription_delete(client, service):
     if l is not None:
         db.session.delete(l)
         db.session.commit()
-    return jsonify(Error.NONE)
+    return Error.NONE


### PR DESCRIPTION
This pull request makes sure errors actually return non-OK HTTP status codes. Before, all requests (that didn't cause an actual uncaught exception serverside) returned 200. With this change, they instead return what they should according to the documentation, and as for the undocumented ones according to common sense.

With this pull request, the errors are mapped as following:
- `Error.NONE` - **200** OK
- `Error.INVALID_CLIENT` - **400** Bad request
- `Error.INVALID_SERVICE` - **400** Bad request
- `Error.INVALID_SECRET` - **400** Bad request
- `Error.DUPLICATE_LISTEN` - **409** Conflict
- `Error.RATE_TOOFAST` - **429** Too many requests
- `Error.SERVICE_NOTFOUND` - **404** Not found
- `Error.ARGUMENT_MISSING` - **400** Bad request
- `Error.INVALID_PUBKEY` - **400** Bad request (Though this error is never used.)
- `Error.CONNECTION_CLOSING` - **499** Client closed request (I wasn't sure about this one either, since it also goes unused.)
- `Error.NO_CHANGES` - **400** Bad request

Pretty nice, eh? This also resolves #17.
