### PR TITLE
Fix running on non-Linux systems

### DIFF
--- a/models/gcm.py
+++ b/models/gcm.py
@@ -26,7 +26,7 @@ class Gcm(db.Model):
         data = {
             "uuid": self.service.as_dict(),
             "gcm_registration_id": self.gcmId,
-            "timestamp": int(self.timestamp_created.strftime('%s')),
+            "timestamp": int((self.timestamp_created - datetime.utcfromtimestamp(0)).total_seconds()),
         }
         return data
 

--- a/models/message.py
+++ b/models/message.py
@@ -30,5 +30,5 @@ class Message(db.Model):
             "title": self.title,
             "link": self.link,
             "level": self.level,
-            "timestamp": int(self.timestamp_created.strftime('%s'))
+            "timestamp": int((self.timestamp_created - datetime.utcfromtimestamp(0)).total_seconds())
         }

--- a/models/service.py
+++ b/models/service.py
@@ -49,7 +49,7 @@ class Service(db.Model):
         data = {
             "public": self.public,
             "name": self.name,
-            "created": int(self.timestamp_created.strftime("%s")),
+            "created": int((self.timestamp_created - datetime.utcfromtimestamp(0)).total_seconds()),
             "icon": self.icon,
         }
         if secret:

--- a/models/subscription.py
+++ b/models/subscription.py
@@ -33,7 +33,7 @@ class Subscription(db.Model):
         data = {
             "uuid": self.device,
             "service": self.service.as_dict(),
-            "timestamp": int(self.timestamp_created.strftime('%s')),
-            "timestamp_checked": int(self.timestamp_checked.strftime('%s'))
+            "timestamp": int((self.timestamp_created - datetime.utcfromtimestamp(0)).total_seconds()),
+            "timestamp_checked": int((self.timestamp_created - datetime.utcfromtimestamp(0)).total_seconds())
         }
         return data


### PR DESCRIPTION
The time formatting directive `%s` is non-standard and therefore not available on non-Linux systems. This pull request switches over all uses of `%s` to a cross-platform approach. It's still not entirely easy to get the Pushjet server running on Windows, for example, but with this PR it's at least _possible_ without having to modify the code.
