### PR TITLE
Raise an error when trying to unsubscribe to a service that isn't subscribed to

### DIFF
--- a/controllers/subscription.py
+++ b/controllers/subscription.py
@@ -41,4 +41,5 @@ def subscription_delete(client, service):
     if l is not None:
         db.session.delete(l)
         db.session.commit()
-    return Error.NONE
+        return Error.NONE
+    return Error.NOT_SUBSCRIBED

--- a/utils.py
+++ b/utils.py
@@ -30,7 +30,8 @@ class Error(object):
     INVALID_PUBKEY = _e.__func__('Invalid public key supplied. Please send a DER formatted base64 encoded key.', 8, 400) # Bad request
     CONNECTION_CLOSING = _e.__func__('Connection closing', 9, 499) # Client closed request
     NO_CHANGES = _e.__func__('No changes were made', 10, 400) # Bad request
- 
+    NOT_SUBSCRIBED = _e.__func__('Not subscribed to that service', 11, 409) # Conflict
+
     @staticmethod
     def ARGUMENT_MISSING(arg):
         return Error._e('Missing argument {}'.format(arg), 7, 400) # Bad request


### PR DESCRIPTION
An error is raised when trying to subscribe to a service that's already subscribed to. To be consistent, with this pull request, an error is also raised when trying to unsubscribe to a service that's not subscribed to.
