### PR TITLE
Fix Emoji support (and for 4-plus-byte Unicode characters in general)

### DIFF
--- a/application.py
+++ b/application.py
@@ -32,6 +32,8 @@ app.debug = config.debug or int(getenv('FLASK_DEBUG', 0)) > 0
 app.config['SQLALCHEMY_DATABASE_URI'] = config.database_uri
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db.init_app(app)
+with app.app_context():
+    db.engine.execute("SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_ci'")
 
 
 @app.route('/')

--- a/database.sql
+++ b/database.sql
@@ -18,8 +18,8 @@ CREATE TABLE IF NOT EXISTS `subscription` (
   PRIMARY KEY (`id`)
 )
   ENGINE = InnoDB
-  DEFAULT CHARSET = utf8
-  COLLATE = utf8_unicode_ci;
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 
 -- -----------------------------------------------------
@@ -38,8 +38,8 @@ CREATE TABLE IF NOT EXISTS `message` (
   PRIMARY KEY (`id`)
 )
   ENGINE = InnoDB
-  DEFAULT CHARSET = utf8
-  COLLATE = utf8_unicode_ci;
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 -- -----------------------------------------------------
 -- Table `service`
@@ -56,8 +56,8 @@ CREATE TABLE IF NOT EXISTS `service` (
   PRIMARY KEY (`id`)
 )
   ENGINE = InnoDB
-  DEFAULT CHARSET = utf8
-  COLLATE = utf8_unicode_ci;
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 -- -----------------------------------------------------
 -- Table `gcm`
@@ -74,8 +74,8 @@ CREATE TABLE IF NOT EXISTS `gcm` (
   PRIMARY KEY (`id`)
 )
   ENGINE = InnoDB
-  DEFAULT CHARSET = utf8
-  COLLATE = utf8_unicode_ci;
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 SET SQL_MODE = @OLD_SQL_MODE;
 SET FOREIGN_KEY_CHECKS = @OLD_FOREIGN_KEY_CHECKS;

--- a/tests.py
+++ b/tests.py
@@ -35,8 +35,9 @@ class PushjetTestCase(unittest.TestCase):
         random_str = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(length))
 
         if unicode:
-            random_str = random_str[:-7] + u'カップケーキ'
-            random_str = u'☕' + random_str
+            random_str = random_str[:-7] + 'カップケーキ'
+            # It's important that the following is a 4+-byte Unicode character.
+            random_str = '😉' + random_str
 
         return random_str
 


### PR DESCRIPTION
This pull request fixes support for all Unicode characters, and not only those 3 bytes and shorter, which is the default in MySQL. Turns out there are quite a few hoops you need to jump through.

The main Pushjet API server will of course need to update the `DEFAULT CHARSET` and `COLLATE` for each table manually, since the change that fixes that is in `database.sql`, which is only used when creating a new database.

And yo, #7! You're out!
